### PR TITLE
[RNG] complete_cb called after the final frame has been sent

### DIFF
--- a/lib/twr_ss_ext/src/twr_ss_ext.c
+++ b/lib/twr_ss_ext/src/twr_ss_ext.c
@@ -285,17 +285,12 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
 
                 if (uwb_start_tx(inst).start_tx_error){
                     STATS_INC(g_twr_ss_ext_stat, tx_error);
+                    dpl_sem_release(&rng->sem);
+                    rng_issue_complete(inst);
                 }
                 else{
                     STATS_INC(g_twr_ss_ext_stat, complete);
-                }
-
-                dpl_sem_release(&rng->sem);
-                if(!(SLIST_EMPTY(&inst->interface_cbs))) {
-                    SLIST_FOREACH(cbs_i, &inst->interface_cbs, next) {
-                        if (cbs_i != NULL && cbs_i->complete_cb)
-                            if(cbs_i->complete_cb(inst, cbs_i)) continue;
-                    }
+                    rng->control.complete_after_tx = 1;
                 }
                 break;
             }
@@ -308,12 +303,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
 
                 STATS_INC(g_twr_ss_ext_stat, complete);
                 dpl_sem_release(&rng->sem);
-                if(!(SLIST_EMPTY(&inst->interface_cbs))) {
-                    SLIST_FOREACH(cbs_i, &inst->interface_cbs, next) {
-                        if (cbs_i != NULL && cbs_i->complete_cb)
-                            if(cbs_i->complete_cb(inst, cbs_i)) continue;
-                    }
-                }
+                rng_issue_complete(inst);
                 break;
             }
         default:

--- a/lib/uwb_rng/include/uwb_rng/uwb_rng.h
+++ b/lib/uwb_rng/include/uwb_rng/uwb_rng.h
@@ -77,6 +77,7 @@ struct uwb_rng_config{
 //! Range control parameters.
 typedef struct _uwb_rng_control_t{
     uint16_t delay_start_enabled:1;  //!< Set for enabling delayed start
+    uint16_t complete_after_tx:1;    //!< Set by ranging state machine to say that exchange is complete after next tx
 }uwb_rng_control_t;
 
 //! Range status parameters
@@ -188,6 +189,7 @@ void uwb_rng_clear_twr_data(struct _twr_data_t *s);
 dpl_float64_t uwb_rng_twr_to_tof(struct uwb_rng_instance * rng, uint16_t idx);
 dpl_float64_t uwb_rng_tof_to_meters(dpl_float64_t ToF);
 void uwb_rng_calc_rel_tx(struct uwb_rng_instance * rng, struct uwb_rng_txd *ret, struct uwb_rng_config *cfg, uint64_t ts, uint16_t rx_data_len);
+void rng_issue_complete(struct uwb_dev * inst);
 
 #ifndef __KERNEL__
 float uwb_rng_path_loss(float Pt, float G, float fc, float R);


### PR DESCRIPTION
Inspired by [mynewt-dw1000-core:32](https://github.com/Decawave/mynewt-dw1000-core/issues/32) and generalised for uwb-core. 

Basically waits with issuing the complete_cb until the FINAL frame has been sent by the requester. 
Previously the semaphore was released and complete_cb called when the start_tx command had been sent which could 
lead to another request aborting the current tx operation. 

@pkettle I've tested this on nucleos, please have a look over and test this on your side too. 