### PR TITLE
lib/twr_*: enable stats optionally

### DIFF
--- a/lib/tofdb/src/tofdb.c
+++ b/lib/tofdb/src/tofdb.c
@@ -28,7 +28,7 @@ int tofdb_get_tof(uint16_t addr, uint32_t *tof)
             goto ret;
         }
     }
-    return OS_ENOENT;
+    return DPL_ENOENT;
 ret:
     return OS_OK;
 }

--- a/lib/twr_ds/syscfg.yml
+++ b/lib/twr_ds/syscfg.yml
@@ -10,3 +10,6 @@ syscfg.defs:
       TWR_DS_RX_TIMEOUT:
         description: 'TOA timeout delay for DS TWR (usec)'
         value: ((uint16_t)0x30)
+      TWR_DS_STATS:
+        description: 'Enable statistics for the twr_ds module'
+        value: 1

--- a/lib/twr_ds_ext/syscfg.yml
+++ b/lib/twr_ds_ext/syscfg.yml
@@ -10,3 +10,6 @@ syscfg.defs:
       TWR_DS_EXT_RX_TIMEOUT:
         description: 'TOA timeout delay for DS TWR extended frame (usec)'
         value: ((uint16_t)0x40)
+      TWR_DS_EXT_STATS:
+        description: 'Enable statistics for the twr_ds_ext module'
+        value: 1

--- a/lib/twr_ds_ext_nrng/src/twr_ds_ext_nrng.c
+++ b/lib/twr_ds_ext_nrng/src/twr_ds_ext_nrng.c
@@ -36,6 +36,7 @@
 #include <hal/hal_gpio.h>
 #include "bsp/bsp.h"
 
+#include <stats/stats.h>
 #include <dw1000/dw1000_regs.h>
 #include <dw1000/dw1000_dev.h>
 #include <dw1000/dw1000_hal.h>
@@ -65,6 +66,7 @@ static struct uwb_mac_interface g_cbs = {
             .final_cb = tx_final_cb,
 };
 
+#if MYNEWT_VAL(TWR_DS_EXT_NRNG_STATS)
 STATS_SECT_START(twr_ds_ext_nrng_stat_section)
     STATS_SECT_ENTRY(complete)
     STATS_SECT_ENTRY(rx_error)
@@ -78,6 +80,11 @@ STATS_NAME_START(twr_ds_ext_nrng_stat_section)
 STATS_NAME_END(twr_ds_ext_nrng_stat_section)
 
 static STATS_SECT_DECL(twr_ds_ext_nrng_stat_section) g_stat;
+#define DS_STATS_INC(__X) STATS_INC(g_stat, __X)
+#else
+#define DS_STATS_INC(__X) {}
+#endif
+
 
 static struct uwb_rng_config g_config = {
     .tx_holdoff_delay = MYNEWT_VAL(TWR_DS_EXT_NRNG_TX_HOLDOFF),         // Send Time delay in usec.
@@ -96,6 +103,7 @@ void twr_ds_ext_nrng_pkg_init(void){
     printf("{\"utime\": %lu,\"msg\": \"twr_ds_ext_nrng_pkg_init\"}\n",os_cputime_ticks_to_usecs(os_cputime_get32()));
     uwb_mac_append_interface(hal_dw1000_inst(0), &g_cbs);
 
+#if MYNEWT_VAL(TWR_DS_EXT_NRNG_STATS)
     int rc = stats_init(
     STATS_HDR(g_stat),
     STATS_SIZE_INIT_PARMS(g_stat, STATS_SIZE_32),
@@ -104,6 +112,7 @@ void twr_ds_ext_nrng_pkg_init(void){
 
     rc = stats_register("twr_ds_ext_nrng", STATS_HDR(g_stat));
     assert(rc == 0);
+#endif
 }
 
 
@@ -145,7 +154,7 @@ rx_timeout_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs){
     if(inst->fctrl != FCNTL_IEEE_N_RANGES_16){
         return false;
     }
-    STATS_INC(g_stat, rx_timeout);
+    DS_STATS_INC(rx_timeout);
     assert(inst->nrng);
     switch(inst->nrng->code){
         case UWB_DATA_CODE_DS_TWR_NRNG_EXT ... UWB_DATA_CODE_DS_TWR_NRNG_EXT_FINAL:
@@ -191,7 +200,7 @@ rx_error_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs){
     if(inst->fctrl != FCNTL_IEEE_N_RANGES_16){
         return false;
     }
-    STATS_INC(g_stat, rx_error);
+    DS_STATS_INC(rx_error);
     assert(inst->nrng);
     struct nrng_instance * nrng = inst->nrng;
     os_error_t err = os_sem_release(&nrng->sem);
@@ -371,7 +380,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
                     if (cbs!=NULL && cbs->start_tx_error_cb)
                         cbs->start_tx_error_cb(inst, cbs);
                 }else{
-                    STATS_INC(g_stat, complete);
+                    DS_STATS_INC(complete);
                     os_sem_release(&nrng->sem);
                     struct uwb_mac_interface * cbs = NULL;
                     if(!(SLIST_EMPTY(&inst->interface_cbs))){
@@ -416,7 +425,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
                 if(idx == nnodes -1){
                     os_sem_release(&nrng->sem);
                     nrng->resp_count = 0;
-                    STATS_INC(g_stat, complete);
+                    DS_STATS_INC(complete);
                     struct uwb_mac_interface * cbs = NULL;
                     if(!(SLIST_EMPTY(&inst->interface_cbs))){
                         SLIST_FOREACH(cbs, &inst->interface_cbs, next){

--- a/lib/twr_ds_ext_nrng/syscfg.yml
+++ b/lib/twr_ds_ext_nrng/syscfg.yml
@@ -12,3 +12,6 @@ syscfg.defs:
         value: ((uint16_t)0x10)
       TWR_DS_EXT_NRNG_TX_GUARD_DELAY:
         value: ((uint16_t)0x150)
+      TWR_DS_EXT_NRNG_STATS:
+        description: 'Enable statistics for the twr_ds_ext_nrng module'
+        value: 1

--- a/lib/twr_ds_nrng/syscfg.yml
+++ b/lib/twr_ds_nrng/syscfg.yml
@@ -12,3 +12,6 @@ syscfg.defs:
         value: ((uint16_t)0x10)
       TWR_DS_NRNG_TX_GUARD_DELAY:
         value: ((uint16_t)0x100)
+      TWR_DS_NRNG_STATS:
+        description: 'Enable statistics for the twr_ds_nrng module'
+        value: 1

--- a/lib/twr_ss/src/twr_ss.c
+++ b/lib/twr_ss/src/twr_ss.c
@@ -76,6 +76,7 @@ static struct uwb_mac_interface g_cbs[] = {
 #endif
 };
 
+#if MYNEWT_VAL(TWR_SS_STATS)
 STATS_SECT_START(twr_ss_stat_section)
     STATS_SECT_ENTRY(complete)
     STATS_SECT_ENTRY(tx_error)
@@ -88,6 +89,9 @@ STATS_NAME_END(twr_ss_stat_section)
 
 STATS_SECT_DECL(twr_ss_stat_section) g_twr_ss_stat;
 #define SS_STATS_INC(__X) STATS_INC(g_twr_ss_stat, __X)
+#else
+#define SS_STATS_INC(__X) {}
+#endif
 
 static struct uwb_rng_config g_config = {
     .tx_holdoff_delay = MYNEWT_VAL(TWR_SS_TX_HOLDOFF),         // Send Time delay in usec.
@@ -143,6 +147,7 @@ twr_ss_pkg_init(void)
         uwb_rng_append_config(g_cbs[i].inst_ptr, &g_rng_cfgs[i]);
     }
 
+#if MYNEWT_VAL(TWR_SS_STATS)
     rc = stats_init(
         STATS_HDR(g_twr_ss_stat),
         STATS_SIZE_INIT_PARMS(g_twr_ss_stat, STATS_SIZE_32),
@@ -151,6 +156,7 @@ twr_ss_pkg_init(void)
 
     rc |= stats_register("twr_ss", STATS_HDR(g_twr_ss_stat));
     assert(rc == 0);
+#endif
 }
 
 /**

--- a/lib/twr_ss/syscfg.yml
+++ b/lib/twr_ss/syscfg.yml
@@ -10,3 +10,6 @@ syscfg.defs:
       TWR_SS_RX_TIMEOUT:
         description: 'TOA timeout delay for SS TWR (usec)'
         value: ((uint16_t)0x30)
+      TWR_SS_STATS:
+        description: 'Enable statistics for the twr_ss module'
+        value: 1

--- a/lib/twr_ss_ack/src/twr_ss_ack.c
+++ b/lib/twr_ss_ack/src/twr_ss_ack.c
@@ -78,7 +78,7 @@ static struct uwb_mac_interface g_cbs[] = {
 #endif
 };
 
-
+#if MYNEWT_VAL(TWR_SS_ACK_STATS)
 STATS_SECT_START(twr_ss_ack_stat_section)
     STATS_SECT_ENTRY(complete)
     STATS_SECT_ENTRY(tx_error)
@@ -97,7 +97,9 @@ STATS_NAME_END(twr_ss_ack_stat_section)
 
 STATS_SECT_DECL(twr_ss_ack_stat_section) g_twr_ss_ack_stat;
 #define SS_STATS_INC(__X) STATS_INC(g_twr_ss_ack_stat, __X)
-
+#else
+#define SS_STATS_INC(__X) {}
+#endif
 
 static struct uwb_rng_config g_config = {
     .tx_holdoff_delay = MYNEWT_VAL(TWR_SS_ACK_TX_HOLDOFF),       // Send Time delay in usec.
@@ -154,6 +156,7 @@ twr_ss_ack_pkg_init(void)
         uwb_rng_append_config(g_cbs[i].inst_ptr, &g_rng_cfgs[i]);
     }
 
+#if MYNEWT_VAL(TWR_SS_ACK_STATS)
     rc = stats_init(
         STATS_HDR(g_twr_ss_ack_stat),
         STATS_SIZE_INIT_PARMS(g_twr_ss_ack_stat, STATS_SIZE_32),
@@ -162,6 +165,7 @@ twr_ss_ack_pkg_init(void)
 
     rc |= stats_register("twr_ss_ack", STATS_HDR(g_twr_ss_ack_stat));
     assert(rc == 0);
+#endif
 }
 
 /**

--- a/lib/twr_ss_ack/syscfg.yml
+++ b/lib/twr_ss_ack/syscfg.yml
@@ -10,3 +10,6 @@ syscfg.defs:
       TWR_SS_ACK_RX_TIMEOUT:
         description: 'TOA timeout delay for SS TWR (usec)'
         value: ((uint16_t)0x100)
+      TWR_SS_ACK_STATS:
+        description: 'Enable statistics for the twr_ss_ack module'
+        value: 1

--- a/lib/twr_ss_ext/syscfg.yml
+++ b/lib/twr_ss_ext/syscfg.yml
@@ -10,3 +10,6 @@ syscfg.defs:
       TWR_SS_EXT_RX_TIMEOUT:
         description: 'TOA timeout delay for SS EXT TWR (usec)'
         value: ((uint16_t)0x40)
+      TWR_SS_EXT_STATS:
+        description: 'Enable statistics for the twr_ss_ext module'
+        value: 1

--- a/lib/twr_ss_ext_nrng/syscfg.yml
+++ b/lib/twr_ss_ext_nrng/syscfg.yml
@@ -12,6 +12,9 @@ syscfg.defs:
         value: ((uint16_t)0x10)
       TWR_SS_EXT_NRNG_TX_GUARD_DELAY:
         value: ((uint32_t)0x90)
+      TWR_SS_EXT_NRNG_STATS:
+        description: 'Enable statistics for the twr_ss_ext_nrng module'
+        value: 1
       CELL_ENABLED:
         description: 'Cell network model on slot decoding'
         value: 0

--- a/lib/twr_ss_nrng/src/twr_ss_nrng.c
+++ b/lib/twr_ss_nrng/src/twr_ss_nrng.c
@@ -35,6 +35,7 @@
 #include <hal/hal_spi.h>
 #include <hal/hal_gpio.h>
 
+#include <stats/stats.h>
 #include <uwb/uwb.h>
 #include <uwb/uwb_mac.h>
 #include <uwb/uwb_ftypes.h>
@@ -51,6 +52,30 @@
 #ifndef DIAGMSG
 #define DIAGMSG(s,u)
 #endif
+
+#if MYNEWT_VAL(TWR_SS_NRNG_STATS)
+STATS_SECT_START(twr_ss_nrng_stat_section)
+    STATS_SECT_ENTRY(rx_error)
+    STATS_SECT_ENTRY(rx_timeout)
+    STATS_SECT_ENTRY(rx_complete)
+    STATS_SECT_ENTRY(rx_unsolicited)
+    STATS_SECT_ENTRY(reset)
+STATS_SECT_END
+
+STATS_NAME_START(twr_ss_nrng_stat_section)
+    STATS_NAME(twr_ss_nrng_stat_section, rx_error)
+    STATS_NAME(twr_ss_nrng_stat_section, rx_timeout)
+    STATS_NAME(twr_ss_nrng_stat_section, rx_complete)
+    STATS_NAME(twr_ss_nrng_stat_section, rx_unsolicited)
+    STATS_NAME(twr_ss_nrng_stat_section, reset)
+STATS_NAME_END(twr_ss_nrng_stat_section)
+
+STATS_SECT_DECL(twr_ss_nrng_stat_section) g_twr_ss_nrng_stat;
+#define SS_STATS_INC(__X) STATS_INC(g_twr_ss_nrng_stat, __X)
+#else
+#define SS_STATS_INC(__X) {}
+#endif
+
 
 static bool rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs);
 static bool rx_timeout_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs);
@@ -93,6 +118,17 @@ void twr_ss_nrng_pkg_init(void)
     g_cbs.inst_ptr = nrng;
     uwb_mac_append_interface(udev, &g_cbs);
     nrng_append_config(nrng, &g_rng_cfgs);
+
+#if MYNEWT_VAL(TWR_SS_NRNG_STATS)
+    int rc = stats_init(
+    STATS_HDR(g_twr_ss_nrng_stat),
+    STATS_SIZE_INIT_PARMS(g_twr_ss_nrng_stat, STATS_SIZE_32),
+    STATS_NAME_INIT_PARMS(twr_ss_nrng_stat_section));
+    assert(rc == 0);
+
+    rc = stats_register("twr_ss_nrng", STATS_HDR(g_twr_ss_nrng_stat));
+    assert(rc == 0);
+#endif
 }
 
 
@@ -126,7 +162,7 @@ rx_error_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
         return false;
 
     if(dpl_sem_get_count(&nrng->sem) == 0){
-        NRNG_STATS_INC(rx_error);
+        SS_STATS_INC(rx_error);
         dpl_error_t err = dpl_sem_release(&nrng->sem);
         assert(err == DPL_OK);
         return true;
@@ -150,7 +186,7 @@ rx_timeout_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
         return false;
 
     if(dpl_sem_get_count(&nrng->sem) == 0){
-        NRNG_STATS_INC(rx_timeout);
+        SS_STATS_INC(rx_timeout);
         // In the case of a NRNG timeout is used to mark the end of the request
         // and is used to call the completion callback
         if(!(SLIST_EMPTY(&inst->interface_cbs))){
@@ -179,7 +215,7 @@ reset_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
     if(dpl_sem_get_count(&nrng->sem) == 0){
         dpl_error_t err = dpl_sem_release(&nrng->sem);
         assert(err == DPL_OK);
-        NRNG_STATS_INC(reset);
+        SS_STATS_INC(reset);
         return true;
     }
     else
@@ -203,7 +239,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
 
     if(dpl_sem_get_count(&nrng->sem) == 1){
         // unsolicited inbound
-        NRNG_STATS_INC(rx_unsolicited);
+        SS_STATS_INC(rx_unsolicited);
         return false;
     }
 
@@ -213,7 +249,7 @@ rx_complete_cb(struct uwb_dev * inst, struct uwb_mac_interface * cbs)
     if (_frame->dst_address != inst->my_short_address && _frame->dst_address != UWB_BROADCAST_ADDRESS)
         return true;
 
-    NRNG_STATS_INC(rx_complete);
+    SS_STATS_INC(rx_complete);
 
     switch(_frame->code){
         case UWB_DATA_CODE_SS_TWR_NRNG:

--- a/lib/twr_ss_nrng/syscfg.yml
+++ b/lib/twr_ss_nrng/syscfg.yml
@@ -12,6 +12,9 @@ syscfg.defs:
         value: ((uint16_t)0x10)
       TWR_SS_NRNG_TX_GUARD_DELAY:
         value: ((uint32_t)0x120)
+      TWR_SS_NRNG_STATS:
+        description: 'Enable statistics for the twr_ss_nrng module'
+        value: 1
       CELL_ENABLED:
         description: 'Cell network model on slot decoding'
         value: 1

--- a/sys/uwbcfg/src/uwbcfg.c
+++ b/sys/uwbcfg/src/uwbcfg.c
@@ -149,7 +149,7 @@ uwbcfg_set(int argc, char **argv, char *val)
                 return CONF_VALUE_SET(val, CONF_STRING, g_uwb_config[i]);
         }
     }
-    return OS_ENOENT;
+    return DPL_ENOENT;
 }
 
 char*


### PR DESCRIPTION
I'm trying to support `uwb-core` with RIOT. As the `stats` module is quite mynwet specific it would be nice to not always enable. This PR adds the  `TWR_%_ENABLE` options for all `lib/twr_%` modules. I followed the same approach as done for `uwb_rng`. Let me know if that is the correct approach, I can adapt as needed.

This PR as well replaces a couple of occurrences of `OS_ENOENT` by `DPL_ENOENT`