### PR TITLE
Add DWM1001 BSP support for the LIS2DH12 accelerometer

### DIFF
--- a/hw/bsp/dwm1001/pkg.yml
+++ b/hw/bsp/dwm1001/pkg.yml
@@ -45,3 +45,9 @@ pkg.deps.CIR_ENABLED:
 
 pkg.deps.BLE_LP_CLOCK:
     - "@apache-mynewt-nimble/nimble/drivers/nrf52"
+
+pkg.deps.LIS2DH12_ONB:
+    - "@apache-mynewt-core/hw/drivers/sensors/lis2dh12"
+
+pkg.init:
+    config_lis2dh12_sensor: 'MYNEWT_VAL(DWM1001_DEV_SYSINIT_STAGE_LIS2DH12)'

--- a/hw/bsp/dwm1001/src/hal_bsp.c
+++ b/hw/bsp/dwm1001/src/hal_bsp.c
@@ -42,6 +42,31 @@
 #include "os/os_dev.h"
 #include "bsp/bsp.h"
 
+#if MYNEWT_VAL(LIS2DH12_ONB)
+#include "lis2dh12/lis2dh12.h"
+static struct lis2dh12 lis2dh12;
+#endif
+
+#if MYNEWT_VAL(LIS2DH12_ONB)
+static struct sensor_itf i2c_0_itf_lis = {
+    .si_type = SENSOR_ITF_I2C,
+    .si_num  = 0,
+    .si_addr = 0x19,
+    .si_ints = {
+        { /* TODO: determine correct values */
+            .host_pin = 25,
+            .device_pin = 0,
+            .active = true
+        },
+        { /* TODO: determine correct values */
+            .host_pin = 25,
+            .device_pin = 0,
+            .active = true
+        }
+    }
+};
+#endif
+
 #if MYNEWT_VAL(SPI_0_MASTER)
 struct dpl_sem g_spi0_sem;
 
@@ -129,6 +154,33 @@ hal_bsp_get_nvic_priority(int irq_num, uint32_t pri)
     return cfg_pri;
 }
 
+int
+config_lis2dh12_sensor(void)
+{
+#if MYNEWT_VAL(LIS2DH12_ONB)
+    int rc;
+    struct os_dev *dev;
+    struct lis2dh12_cfg cfg;
+
+    dev = (struct os_dev *) os_dev_open("lis2dh12_0", OS_TIMEOUT_NEVER, NULL);
+    assert(dev != NULL);
+
+
+    memset(&cfg, 0, sizeof(cfg));
+
+    cfg.lc_s_mask = SENSOR_TYPE_ACCELEROMETER;
+    cfg.lc_rate = LIS2DH12_DATA_RATE_HN_1344HZ_L_5376HZ;
+    cfg.lc_fs = LIS2DH12_FS_2G;
+    cfg.lc_pull_up_disc = 1;
+
+    rc = lis2dh12_config((struct lis2dh12 *)dev, &cfg);
+    SYSINIT_PANIC_ASSERT(rc == 0);
+
+    os_dev_close(dev);
+#endif
+    return 0;
+}
+
 
 void
 hal_bsp_init(void)
@@ -142,6 +194,13 @@ hal_bsp_init(void)
 
     /* Create all available nRF52832 peripherals */
     nrf52_periph_create();
+
+#if MYNEWT_VAL(LIS2DH12_ONB)
+    rc = os_dev_create((struct os_dev *) &lis2dh12, "lis2dh12_0",
+                       OS_DEV_INIT_PRIMARY, 0, lis2dh12_init,
+                       (void *)&i2c_0_itf_lis);
+    assert(rc == 0);
+#endif
 
 #if MYNEWT_VAL(SPI_0_MASTER)
     rc = dpl_sem_init(&g_spi0_sem, 0x1);

--- a/hw/bsp/dwm1001/syscfg.yml
+++ b/hw/bsp/dwm1001/syscfg.yml
@@ -58,6 +58,14 @@ syscfg.defs:
     DW1000_DEVICE_0_RX_ANT_DLY:
         description: 'RX_ANT_DLY'
         value: 0x4042
+    LIS2DH12_ONB:
+        description: 'Enable DWM1001 onboard LIS2DH12 sensor'
+        value:  0
+
+    DWM1001_DEV_SYSINIT_STAGE_LIS2DH12:
+        description: >
+            Sysinit stage for the DWM1001-dev; initializes the LIS2DH12 sensor.
+        value: 400
 
 syscfg.vals:
     MCU_TARGET: nRF52832


### PR DESCRIPTION
Hey guys,

this PR adds mynewt driver support for the LIS2DH12 accelerometer integrated in DWM1001-DEV boards.
This is essentially the same as [this pull request on apache's DWM1001-dev bsp](https://github.com/apache/mynewt-core/pull/2639), since one seems to have to decide between this one and theirs.

Here is an example application:
```c
#include <assert.h>
#include <string.h>
#include <stdio.h>
#include <math.h>
#include "sysinit/sysinit.h"
#include "os/os.h"
#include "bsp/bsp.h"
#include "hal/hal_gpio.h"
#include "hal/hal_bsp.h"
#include "hal/hal_i2c.h"
#include "mcu/nrf52_hal.h"
#ifdef ARCH_sim
#include "mcu/mcu_sim.h"
#endif

#include <config/config.h>

#include <sensor/sensor.h>
#include "sensor/accel.h"
#include <lis2dh12/lis2dh12.h>

#if MYNEWT_VAL(DW1000_DEVICE_0)
#include <dw1000/dw1000_hal.h>
#endif

int accel_data_cb(struct sensor* sensor, void* a, void* databuf, sensor_type_t sensorType) {
    if(!databuf) { return SYS_EINVAL; }
    struct sensor_accel_data* sad = (struct sensor_accel_data*) databuf;
    if (!sad->sad_x_is_valid || !sad->sad_y_is_valid || !sad->sad_z_is_valid) { return SYS_EINVAL; }
    printf("%s: [ secs: %ld usecs: %d cputime: %u ]\n",
                   "LISTENER_CB",
                   (long int)sensor->s_sts.st_ostv.tv_sec,
                   (int)sensor->s_sts.st_ostv.tv_usec,
                   (unsigned int)sensor->s_sts.st_cputime);

    printf("x = %f, y = %f, z = %f\n", sad->sad_x, sad->sad_y, sad->sad_z);
    return 0;
}

static struct sensor_listener sensor_listener = {
    .sl_sensor_type = SENSOR_TYPE_ACCELEROMETER,
    .sl_func = accel_data_cb,  
    .sl_arg = NULL
};

 

int main(int argc, char **argv){
    sysinit();

    struct sensor* accel = sensor_mgr_find_next_bydevname("lis2dh12_0", NULL);
    assert(accel != NULL);

    assert(0 == lis2dh12_set_full_scale(&accel->s_itf, LIS2DH12_FS_2G));
    assert(0 == lis2dh12_set_op_mode(&accel->s_itf, LIS2DH12_OM_HIGH_RESOLUTION));

    sensor_set_poll_rate_ms(accel->s_dev->od_name, 1000 / 50);
    sensor_register_listener(accel, &sensor_listener);

    while (1) {
        os_eventq_run(os_eventq_dflt_get());
    }
    assert(0);
    return 0;
}
```